### PR TITLE
Upload the coverage report instead of sending it to codecov.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ script:
 before_install:
   - pip install codecov
 after_success:
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
@ldko @somexpert 
This MR uses codecov's bash uploader to upload the generated coverage reports which can be accessed by codecov. This hopefully should resolve the issue arising in https://github.com/unt-libraries/m2m/pull/5